### PR TITLE
Add cognitive surgical modules and pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # SurgicalAI
-Created by Dr. Mehdi Ghorbanikarimabad 
+
+Modular framework for cognitive and contraindication-aware surgical assistance.
+
+## Modules
+
+- **Cognitive Decision Engine**: evaluates flap feasibility.
+- **Contraindication Detector**: flags anatomical or systemic risks.
+- **Structural Integrity Validator**: checks biomechanical soundness.
+- **Self-Audit Checker**: ensures pipeline consistency.
+- **Smart Report Generator**: produces summaries of decisions and warnings.
+
+## Usage
+
+```python
+from surgical_ai.pipeline import run_pipeline
+
+context = {
+    "lesion": {"size": 4},
+    "rotation_angle": 42,
+    "lesion_zone": "left_cheek",
+    "heatmap_zone": "left_cheek",
+}
+results = run_pipeline(context)
+print(results["report"].summary)
+```

--- a/surgical_ai/__init__.py
+++ b/surgical_ai/__init__.py
@@ -1,0 +1,27 @@
+"""SurgicalAI cognitive modules package."""
+
+from .cognitive_decision_engine import CognitiveDecisionEngine, DecisionResult
+from .contraindication_detector import (
+    ContraindicationDetector,
+    ContraindicationResult,
+)
+from .structural_integrity_validator import (
+    StructuralIntegrityValidator,
+    IntegrityReport,
+)
+from .self_audit_checker import SelfAuditChecker, AuditResult, AuditLog
+from .report_generator import ReportGenerator, Report
+
+__all__ = [
+    "CognitiveDecisionEngine",
+    "DecisionResult",
+    "ContraindicationDetector",
+    "ContraindicationResult",
+    "StructuralIntegrityValidator",
+    "IntegrityReport",
+    "SelfAuditChecker",
+    "AuditResult",
+    "AuditLog",
+    "ReportGenerator",
+    "Report",
+]

--- a/surgical_ai/cognitive_decision_engine.py
+++ b/surgical_ai/cognitive_decision_engine.py
@@ -1,0 +1,35 @@
+"""Cognitive Decision Engine module.
+
+Evaluates surgical flap plans based on patient data and rules.
+"""
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class DecisionResult:
+    approved: bool
+    message: str
+
+
+class CognitiveDecisionEngine:
+    """Rule-based engine for flap decision making."""
+
+    def evaluate(self, patient_context: Dict[str, Any]) -> DecisionResult:
+        """Evaluate whether the proposed flap is feasible.
+
+        Parameters
+        ----------
+        patient_context: Dict[str, Any]
+            Information about the lesion, anatomy, and patient state.
+
+        Returns
+        -------
+        DecisionResult
+            Outcome of the evaluation with explanatory message.
+        """
+        # Placeholder logic; real implementation would be more complex.
+        lesion = patient_context.get("lesion", {})
+        if lesion.get("size", 0) > 5:
+            return DecisionResult(False, "Lesion too large for simple flap")
+        return DecisionResult(True, "Flap design approved")

--- a/surgical_ai/contraindication_detector.py
+++ b/surgical_ai/contraindication_detector.py
@@ -1,0 +1,25 @@
+"""Contraindication and risk detection module."""
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class ContraindicationResult:
+    contraindication: bool
+    reason: Optional[str] = None
+    suggested_alternative: Optional[str] = None
+
+
+class ContraindicationDetector:
+    """Detects potential contraindications for a surgical flap."""
+
+    def check(self, anatomy_context: Dict[str, Any]) -> ContraindicationResult:
+        """Evaluate anatomy for possible contraindications."""
+        # Simplified rule: flag if lesion is near critical structure
+        if anatomy_context.get("near_nerve", False):
+            return ContraindicationResult(
+                True,
+                reason="Lesion near critical nerve",
+                suggested_alternative="Consider transposition flap",
+            )
+        return ContraindicationResult(False)

--- a/surgical_ai/pipeline.py
+++ b/surgical_ai/pipeline.py
@@ -1,0 +1,44 @@
+"""Example pipeline integrating cognitive surgical modules."""
+from typing import Any, Dict
+
+from .cognitive_decision_engine import CognitiveDecisionEngine
+from .contraindication_detector import ContraindicationDetector
+from .structural_integrity_validator import StructuralIntegrityValidator
+from .self_audit_checker import SelfAuditChecker
+from .report_generator import ReportGenerator
+
+
+def run_pipeline(patient_context: Dict[str, Any]) -> Dict[str, Any]:
+    """Run surgical planning pipeline and return report data."""
+    decision_engine = CognitiveDecisionEngine()
+    contraindication_checker = ContraindicationDetector()
+    integrity_validator = StructuralIntegrityValidator()
+    auditor = SelfAuditChecker()
+    reporter = ReportGenerator()
+
+    decision = decision_engine.evaluate(patient_context)
+    contra = contraindication_checker.check(patient_context)
+    integrity = integrity_validator.validate(
+        {"rotation_angle": patient_context.get("rotation_angle", 0.0)}
+    )
+    audit = auditor.audit(
+        {
+            "lesion_zone": patient_context.get("lesion_zone"),
+            "heatmap_zone": patient_context.get("heatmap_zone"),
+        }
+    )
+    report = reporter.generate(
+        {
+            "flap_status": integrity.flap_design_status,
+            "rotation_angle": integrity.rotation_angle,
+            "decision": decision.message,
+            "contraindication": contra.contraindication,
+        }
+    )
+    return {
+        "decision": decision,
+        "contraindication": contra,
+        "integrity": integrity,
+        "audit": audit,
+        "report": report,
+    }

--- a/surgical_ai/report_generator.py
+++ b/surgical_ai/report_generator.py
@@ -1,0 +1,26 @@
+"""Smart procedural report generation."""
+from dataclasses import dataclass
+from typing import Any, Dict
+import json
+
+
+@dataclass
+class Report:
+    summary: str
+    data: Dict[str, Any]
+
+
+class ReportGenerator:
+    """Generate human-readable and machine-friendly reports."""
+
+    def generate(self, context: Dict[str, Any]) -> Report:
+        """Create a procedural report from context data."""
+        summary = (
+            f"Flap Status: {context.get('flap_status', 'unknown')}; "
+            f"Rotation Angle: {context.get('rotation_angle', 'n/a')}"
+        )
+        return Report(summary=summary, data=context)
+
+    def to_json(self, report: Report) -> str:
+        """Serialize report to JSON."""
+        return json.dumps({"summary": report.summary, **report.data}, indent=2)

--- a/surgical_ai/self_audit_checker.py
+++ b/surgical_ai/self_audit_checker.py
@@ -1,0 +1,40 @@
+"""Self-audit and consistency checker."""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class AuditLog:
+    step: str
+    status: str
+    details: str
+
+
+@dataclass
+class AuditResult:
+    logs: List[AuditLog] = field(default_factory=list)
+    consistent: bool = True
+
+
+class SelfAuditChecker:
+    """Ensures pipeline consistency across processing stages."""
+
+    def audit(self, pipeline_state: Dict[str, Any]) -> AuditResult:
+        """Check for contradictions in pipeline state."""
+        result = AuditResult()
+        lesion_zone = pipeline_state.get("lesion_zone")
+        heatmap_zone = pipeline_state.get("heatmap_zone")
+        if lesion_zone and heatmap_zone and lesion_zone != heatmap_zone:
+            result.consistent = False
+            result.logs.append(
+                AuditLog(
+                    step="zone_alignment",
+                    status="conflict",
+                    details="Lesion and heatmap zones mismatch",
+                )
+            )
+        else:
+            result.logs.append(
+                AuditLog(step="zone_alignment", status="ok", details="Zones aligned")
+            )
+        return result

--- a/surgical_ai/structural_integrity_validator.py
+++ b/surgical_ai/structural_integrity_validator.py
@@ -1,0 +1,29 @@
+"""Structural integrity validation for flap designs."""
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class IntegrityReport:
+    flap_design_status: str
+    rotation_angle: float
+    blood_supply_check: str
+    warnings: List[str]
+
+
+class StructuralIntegrityValidator:
+    """Validates biomechanical and anatomical feasibility."""
+
+    def validate(self, flap_plan: Dict[str, Any]) -> IntegrityReport:
+        """Perform basic integrity checks on a flap plan."""
+        angle = flap_plan.get("rotation_angle", 0.0)
+        warnings: List[str] = []
+        if angle > 50:
+            warnings.append("Rotation angle exceeds recommended maximum")
+        status = "Valid" if not warnings else "Review"
+        return IntegrityReport(
+            flap_design_status=status,
+            rotation_angle=angle,
+            blood_supply_check="Sufficient",
+            warnings=warnings,
+        )


### PR DESCRIPTION
## Summary
- scaffold cognitive decision engine, contraindication detector, integrity validator, self-audit checker, and report generator modules
- add pipeline example integrating new modules
- document usage and module overview in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68962d8371d883328dd3486262cca7c4