### PR TITLE
Refine module stubs with dataclasses and add pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # SurgicalAI
-Created by Dr. Mehdi Ghorbanikarimabad 
+
+Created by Dr. Mehdi Ghorbanikarimabad
+
+## Prototype Structure
+
+This repository contains a modular Python package for exploring
+reconstructive plastic surgery workflows.
+
+### Modules
+
+- `scan` – 3D facial scan ingestion and normalization
+- `landmarks` – anatomical landmark detection and tension line mapping
+- `lesion` – skin lesion classification with Grad-CAM heatmaps
+- `flap` – local flap design suggestion engine
+- `visualization` – 3D rendering of scans, lesions and flaps
+- `output` – report generation and metadata export
+- `pipeline` – orchestrates the above modules into a single workflow
+
+Each module currently provides placeholders for future implementation.
+
+```python
+from surgical_ai.pipeline import SurgicalPipeline
+
+pipeline = SurgicalPipeline()
+# pipeline.run("/path/to/scan.obj")  # raises NotImplementedError until filled in
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+# Core libraries for the SurgicalAI prototype
+pytorch
+torchvision
+open3d
+trimesh
+vedo
+face-alignment
+mediapipe
+dlib
+torchcam
+captum
+plotly
+matplotlib
+pandas
+reportlab

--- a/surgical_ai/__init__.py
+++ b/surgical_ai/__init__.py
@@ -1,0 +1,16 @@
+"""SurgicalAI package.
+
+This package provides modular components for a prototype medical AI
+system targeting reconstructive plastic surgery. Each submodule offers
+placeholders for future implementation.
+"""
+
+__all__ = [
+    "scan",
+    "landmarks",
+    "lesion",
+    "flap",
+    "visualization",
+    "output",
+    "pipeline",
+]

--- a/surgical_ai/flap.py
+++ b/surgical_ai/flap.py
@@ -1,0 +1,38 @@
+"""Flap design suggestion engine."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+
+@dataclass
+class FlapPlan:
+    """Representation of a local flap recommendation."""
+
+    flap_type: str
+    axis: Optional[Tuple[float, float, float]] = None
+    success_rate: Optional[float] = None
+    extra: Dict[str, Any] | None = None
+
+
+class FlapDesigner:
+    """Suggests optimal local flap designs based on lesion data."""
+
+    def suggest(
+        self, lesion_location: Tuple[float, float, float], tension_map: Any
+    ) -> FlapPlan:
+        """Suggest a flap design.
+
+        Parameters
+        ----------
+        lesion_location:
+            3D coordinates of the lesion.
+        tension_map:
+            Representation of facial tension lines.
+
+        Returns
+        -------
+        FlapPlan
+            Information about the proposed flap, e.g., type and orientation.
+        """
+        # TODO: implement rule-based or ML-driven flap suggestion
+        raise NotImplementedError

--- a/surgical_ai/landmarks.py
+++ b/surgical_ai/landmarks.py
@@ -1,0 +1,41 @@
+"""Facial landmark detection utilities.
+
+The :class:`LandmarkDetector` returns :class:`LandmarkResult` containing both
+anatomical points and an optional tension-line representation.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+
+@dataclass
+class LandmarkResult:
+    """Detected landmarks and tension map."""
+
+    landmarks: Dict[str, Tuple[float, float, float]]
+    tension_map: Optional[Any] = None
+
+
+class LandmarkDetector:
+    """Detects anatomical landmarks and optional tension lines."""
+
+    def detect(self, scan: Any) -> LandmarkResult:
+        """Detect landmarks on ``scan``.
+
+        Parameters
+        ----------
+        scan:
+            Normalized 3D scan.
+
+        Returns
+        -------
+        LandmarkResult
+            Mapping of landmark names to 3D coordinates and tension map.
+        """
+        # TODO: integrate with face-alignment or mediapipe
+        raise NotImplementedError
+
+    def map_tension_lines(self, scan: Any) -> Any:
+        """Estimate facial tension lines (e.g., Langer's lines)."""
+        # TODO: implement skin tension estimation
+        raise NotImplementedError

--- a/surgical_ai/lesion.py
+++ b/surgical_ai/lesion.py
@@ -1,0 +1,37 @@
+"""Skin lesion classification and heatmap generation."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class LesionResult:
+    """Probabilistic diagnosis and accompanying heatmap."""
+
+    probabilities: Dict[str, float]
+    heatmap: Optional[Any] = None
+
+
+class LesionDetector:
+    """Classifies skin lesions and produces Grad-CAM heatmaps."""
+
+    def classify(self, image: Any) -> LesionResult:
+        """Return probabilistic diagnosis for ``image``.
+
+        Parameters
+        ----------
+        image:
+            2D projection or UV map of the facial scan.
+
+        Returns
+        -------
+        LesionResult
+            Probabilities for classes and placeholder heatmap.
+        """
+        # TODO: load pretrained CNN and perform inference
+        raise NotImplementedError
+
+    def generate_heatmap(self, image: Any) -> Any:
+        """Generate Grad-CAM style heatmap for ``image``."""
+        # TODO: implement Grad-CAM using torchcam or captum
+        raise NotImplementedError

--- a/surgical_ai/output.py
+++ b/surgical_ai/output.py
@@ -1,0 +1,25 @@
+"""Reporting and logging utilities."""
+
+from dataclasses import asdict
+from typing import Any, Dict
+
+
+class ReportGenerator:
+    """Exports diagnostic and surgical planning results."""
+
+    def save_report(self, data: Dict[str, Any], path: str) -> None:
+        """Save a PDF or text report summarizing ``data``."""
+        # TODO: implement using reportlab or similar library
+        raise NotImplementedError
+
+    def save_metadata(self, data: Dict[str, Any], path: str) -> None:
+        """Save ``data`` to JSON or CSV for downstream use."""
+        # TODO: implement structured metadata export
+        raise NotImplementedError
+
+    def dataclass_to_dict(self, obj: Any) -> Dict[str, Any]:
+        """Utility to convert dataclasses to dictionaries recursively."""
+        try:
+            return asdict(obj)
+        except TypeError:  # not a dataclass
+            return dict(obj)

--- a/surgical_ai/pipeline.py
+++ b/surgical_ai/pipeline.py
@@ -1,0 +1,63 @@
+"""High level orchestration of the SurgicalAI modules.
+
+The :class:`SurgicalPipeline` class demonstrates the expected flow of data
+through the system. Each step delegates to the corresponding submodule and is
+currently a placeholder awaiting real implementations.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .flap import FlapDesigner, FlapPlan
+from .landmarks import LandmarkDetector, LandmarkResult
+from .lesion import LesionDetector, LesionResult
+from .scan import ScanData, ScanProcessor
+
+
+@dataclass
+class PipelineResult:
+    """Aggregate outputs from the full pipeline."""
+
+    scan: ScanData
+    landmarks: LandmarkResult
+    lesion: LesionResult
+    flap: FlapPlan
+
+
+class SurgicalPipeline:
+    """Orchestrates individual modules to produce a surgical plan."""
+
+    def __init__(
+        self,
+        scan_processor: Optional[ScanProcessor] = None,
+        landmark_detector: Optional[LandmarkDetector] = None,
+        lesion_detector: Optional[LesionDetector] = None,
+        flap_designer: Optional[FlapDesigner] = None,
+    ) -> None:
+        self.scan_processor = scan_processor or ScanProcessor()
+        self.landmark_detector = landmark_detector or LandmarkDetector()
+        self.lesion_detector = lesion_detector or LesionDetector()
+        self.flap_designer = flap_designer or FlapDesigner()
+
+    def run(self, path: str | Path) -> PipelineResult:
+        """Execute the pipeline on a Polycam scan located at ``path``.
+
+        This method outlines the interactions between modules but leaves actual
+        implementations to future development.
+        """
+
+        scan = self.scan_processor.load_scan(path)
+        scan = self.scan_processor.normalize(scan)
+
+        landmarks = self.landmark_detector.detect(scan)
+        tension_map = landmarks.tension_map or self.landmark_detector.map_tension_lines(scan)
+
+        # In a full implementation, the scan would be projected to 2D before
+        # lesion analysis. Here we simply pass ``None`` as a placeholder.
+        lesion = self.lesion_detector.classify(None)
+        lesion.heatmap = self.lesion_detector.generate_heatmap(None)
+
+        flap = self.flap_designer.suggest((0.0, 0.0, 0.0), tension_map)
+
+        return PipelineResult(scan=scan, landmarks=landmarks, lesion=lesion, flap=flap)

--- a/surgical_ai/scan.py
+++ b/surgical_ai/scan.py
@@ -1,0 +1,63 @@
+"""Module for 3D scan ingestion and normalization.
+
+This module exposes :class:`ScanProcessor` for loading Polycam exports and
+``ScanData`` which wraps raw and normalized representations.  The functions are
+stubs and should be extended with ``open3d`` or ``trimesh`` integration once
+real data is available.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+@dataclass
+class ScanData:
+    """Container for a 3D scan and related metadata.
+
+    Attributes
+    ----------
+    raw: Any
+        Original scan object as loaded from disk.
+    normalized: Any | None
+        Scan after size/orientation normalization.  ``None`` until processed.
+    """
+
+    raw: Any
+    normalized: Optional[Any] = None
+
+
+class ScanProcessor:
+    """Handles loading and normalizing 3D facial scans."""
+
+    def load_scan(self, file_path: str | Path) -> ScanData:
+        """Load a 3D scan from ``file_path``.
+
+        Parameters
+        ----------
+        file_path:
+            Path to a ``.obj`` or ``.ply`` scan.
+
+        Returns
+        -------
+        ScanData
+            Wrapper containing the raw scan.
+        """
+        # TODO: implement loading using open3d or trimesh
+        raise NotImplementedError
+
+    def normalize(self, scan: ScanData) -> ScanData:
+        """Normalize scale, rotation and orientation of ``scan``.
+
+        Parameters
+        ----------
+        scan:
+            Loaded scan object.
+
+        Returns
+        -------
+        ScanData
+            Updated instance with ``normalized`` field populated.
+        """
+        # TODO: implement normalization logic
+        raise NotImplementedError

--- a/surgical_ai/visualization.py
+++ b/surgical_ai/visualization.py
@@ -1,0 +1,26 @@
+"""3D visualization utilities."""
+
+from typing import Any
+
+from .flap import FlapPlan
+from .lesion import LesionResult
+from .scan import ScanData
+
+
+class Visualizer:
+    """Renders scans, heatmaps and flap designs."""
+
+    def render_face(self, scan: ScanData) -> None:
+        """Render the base 3D facial scan."""
+        # TODO: render using open3d, vedo or plotly
+        raise NotImplementedError
+
+    def overlay_lesion(self, scan: ScanData, lesion: LesionResult) -> None:
+        """Overlay lesion heatmap onto ``scan``."""
+        # TODO: map 2D heatmap back to 3D mesh
+        raise NotImplementedError
+
+    def show_flap(self, scan: ScanData, flap_info: FlapPlan) -> None:
+        """Visualize suggested flap on ``scan``."""
+        # TODO: display flap geometry on mesh
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- define dataclasses for scan, landmark, lesion and flap outputs
- add `SurgicalPipeline` orchestrator and update visualization/output to use structured types
- document pipeline usage in README

## Testing
- `python -m py_compile surgical_ai/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68962bf4ec3c83329cc41a2a01524eb2