### PR TITLE
Add facial analysis module stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Modular framework for cognitive and contraindication-aware surgical assistance.
 - **Structural Integrity Validator**: checks biomechanical soundness.
 - **Self-Audit Checker**: ensures pipeline consistency.
 - **Smart Report Generator**: produces summaries of decisions and warnings.
+- **Facial Analysis**: handles 3D scan ingestion, landmark detection, lesion analysis, flap design, visualization, and reporting.
 
 ## Usage
 
@@ -23,4 +24,14 @@ context = {
 }
 results = run_pipeline(context)
 print(results["report"].summary)
+```
+
+### Facial Analysis Pipeline
+
+```python
+from pathlib import Path
+from surgical_ai.facial_analysis import run_pipeline as facial_run
+
+results = facial_run(Path("face_scan.ply"))
+print(results["flap"].flap_type)
 ```

--- a/surgical_ai/__init__.py
+++ b/surgical_ai/__init__.py
@@ -11,6 +11,19 @@ from .structural_integrity_validator import (
 )
 from .self_audit_checker import SelfAuditChecker, AuditResult, AuditLog
 from .report_generator import ReportGenerator, Report
+from .facial_analysis import (
+    ScanIngestor,
+    ScanData,
+    LandmarkDetector,
+    Landmarks,
+    LesionDetector,
+    LesionAnalysis,
+    FlapDesignEngine,
+    FlapSuggestion,
+    SurgicalVisualizer,
+    OutputLogger,
+    run_pipeline,
+)
 
 __all__ = [
     "CognitiveDecisionEngine",
@@ -24,4 +37,15 @@ __all__ = [
     "AuditLog",
     "ReportGenerator",
     "Report",
+    "ScanIngestor",
+    "ScanData",
+    "LandmarkDetector",
+    "Landmarks",
+    "LesionDetector",
+    "LesionAnalysis",
+    "FlapDesignEngine",
+    "FlapSuggestion",
+    "SurgicalVisualizer",
+    "OutputLogger",
+    "run_pipeline",
 ]

--- a/surgical_ai/facial_analysis/__init__.py
+++ b/surgical_ai/facial_analysis/__init__.py
@@ -1,0 +1,23 @@
+"""Facial analysis modules for reconstructive surgery."""
+
+from .scan_ingestion import ScanIngestor, ScanData
+from .landmark_detection import LandmarkDetector, Landmarks
+from .lesion_detection import LesionDetector, LesionAnalysis
+from .flap_design_engine import FlapDesignEngine, FlapSuggestion
+from .visualization import SurgicalVisualizer
+from .output_logging import OutputLogger
+from .pipeline import run_pipeline
+
+__all__ = [
+    "ScanIngestor",
+    "ScanData",
+    "LandmarkDetector",
+    "Landmarks",
+    "LesionDetector",
+    "LesionAnalysis",
+    "FlapDesignEngine",
+    "FlapSuggestion",
+    "SurgicalVisualizer",
+    "OutputLogger",
+    "run_pipeline",
+]

--- a/surgical_ai/facial_analysis/flap_design_engine.py
+++ b/surgical_ai/facial_analysis/flap_design_engine.py
@@ -1,0 +1,32 @@
+"""Flap design suggestion engine."""
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class FlapSuggestion:
+    """Recommended flap details."""
+
+    flap_type: str
+    axis: float
+    success_probability: float
+
+
+class FlapDesignEngine:
+    """Suggests optimal local flap design based on analysis."""
+
+    def suggest_flap(self, context: Dict[str, Any]) -> FlapSuggestion:
+        """Suggest a flap design for given lesion context.
+
+        Parameters
+        ----------
+        context: Dict[str, Any]
+            Information about lesion location and tension lines.
+
+        Returns
+        -------
+        FlapSuggestion
+            Placeholder suggestion with flap type and metrics.
+        """
+        # Placeholder: rule-based suggestion.
+        return FlapSuggestion(flap_type="rotation", axis=0.0, success_probability=0.0)

--- a/surgical_ai/facial_analysis/landmark_detection.py
+++ b/surgical_ai/facial_analysis/landmark_detection.py
@@ -1,0 +1,24 @@
+"""Facial landmark detection module."""
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class Landmarks:
+    """Collection of facial landmark coordinates."""
+
+    points: Dict[str, Any]
+
+
+class LandmarkDetector:
+    """Detects anatomical landmarks and tension lines."""
+
+    def detect_landmarks(self, scan_data: Any) -> Landmarks:
+        """Detect landmarks on normalized scan."""
+        # Placeholder: use facial landmark libraries.
+        return Landmarks(points={})
+
+    def map_tension_lines(self, scan_data: Any) -> Any:
+        """Estimate Langer's lines or skin tension map."""
+        # Placeholder: compute or approximate tension lines.
+        return None

--- a/surgical_ai/facial_analysis/lesion_detection.py
+++ b/surgical_ai/facial_analysis/lesion_detection.py
@@ -1,0 +1,31 @@
+"""Skin lesion detection using CNN models."""
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class LesionAnalysis:
+    """Result of lesion classification."""
+
+    probability: float
+    heatmap: Any
+
+
+class LesionDetector:
+    """Classifies lesions and produces heatmaps."""
+
+    def classify(self, image: Any) -> LesionAnalysis:
+        """Run lesion classification model.
+
+        Parameters
+        ----------
+        image: Any
+            2D projection or UV map derived from scan.
+
+        Returns
+        -------
+        LesionAnalysis
+            Probability and heatmap placeholder.
+        """
+        # Placeholder: run model and generate Grad-CAM.
+        return LesionAnalysis(probability=0.0, heatmap=None)

--- a/surgical_ai/facial_analysis/output_logging.py
+++ b/surgical_ai/facial_analysis/output_logging.py
@@ -1,0 +1,17 @@
+"""Output and logging utilities for surgical plans."""
+from pathlib import Path
+from typing import Any, Dict
+
+
+class OutputLogger:
+    """Handles export of reports and logs."""
+
+    def export_report(self, data: Dict[str, Any], path: Path) -> None:
+        """Export findings to a PDF or other report format."""
+        # Placeholder: use reportlab or other library.
+        return None
+
+    def save_metadata(self, metadata: Dict[str, Any], path: Path) -> None:
+        """Save analysis metadata to JSON or CSV."""
+        # Placeholder: use json or pandas.
+        return None

--- a/surgical_ai/facial_analysis/pipeline.py
+++ b/surgical_ai/facial_analysis/pipeline.py
@@ -1,0 +1,34 @@
+"""High-level pipeline tying together facial analysis modules."""
+from pathlib import Path
+from typing import Any, Dict
+
+from .scan_ingestion import ScanIngestor
+from .landmark_detection import LandmarkDetector
+from .lesion_detection import LesionDetector
+from .flap_design_engine import FlapDesignEngine
+from .visualization import SurgicalVisualizer
+from .output_logging import OutputLogger
+
+
+def run_pipeline(scan_path: Path) -> Dict[str, Any]:
+    """Execute the facial reconstruction analysis pipeline."""
+    ingestor = ScanIngestor()
+    detector = LandmarkDetector()
+    lesion_model = LesionDetector()
+    flap_engine = FlapDesignEngine()
+    visualizer = SurgicalVisualizer()
+    logger = OutputLogger()
+
+    scan = ingestor.load_scan(scan_path)
+    landmarks = detector.detect_landmarks(scan)
+    lesion = lesion_model.classify(None)
+    flap = flap_engine.suggest_flap({})
+    visualizer.render(scan, lesion.heatmap, flap)
+    logger.export_report({}, Path("report.pdf"))
+    logger.save_metadata({}, Path("analysis.json"))
+    return {
+        "scan": scan,
+        "landmarks": landmarks,
+        "lesion": lesion,
+        "flap": flap,
+    }

--- a/surgical_ai/facial_analysis/scan_ingestion.py
+++ b/surgical_ai/facial_analysis/scan_ingestion.py
@@ -1,0 +1,31 @@
+"""3D facial scan ingestion and normalization utilities."""
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class ScanData:
+    """Normalized scan data placeholder."""
+
+    raw: Any
+
+
+class ScanIngestor:
+    """Loads and normalizes 3D facial scans."""
+
+    def load_scan(self, path: Path) -> ScanData:
+        """Load a 3D scan and return normalized data.
+
+        Parameters
+        ----------
+        path: Path
+            File path to .obj or .ply scan.
+
+        Returns
+        -------
+        ScanData
+            Placeholder for normalized scan representation.
+        """
+        # Placeholder: in real implementation, load mesh and normalize.
+        return ScanData(raw=None)

--- a/surgical_ai/facial_analysis/visualization.py
+++ b/surgical_ai/facial_analysis/visualization.py
@@ -1,0 +1,19 @@
+"""3D visualization utilities for surgical planning."""
+from typing import Any, Optional
+
+
+class SurgicalVisualizer:
+    """Generates 3D visualizations with overlays."""
+
+    def render(
+        self, scan_data: Any, heatmap: Optional[Any] = None, flap: Optional[Any] = None
+    ) -> Any:
+        """Render a 3D view with optional heatmap and flap path.
+
+        Returns
+        -------
+        Any
+            Placeholder for visualization object or figure.
+        """
+        # Placeholder: integrate with 3D visualization library.
+        return None


### PR DESCRIPTION
## Summary
- add `facial_analysis` subpackage with stubs for scan ingestion, landmarks, lesion detection, flap design, visualization, and logging
- expose new modules and pipeline through package and update README with usage example

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689633f91dd08332b0ea6ede62b8a0f6