### PR TITLE
Add GitHub Packages workflows and OpenAPI export

### DIFF
--- a/.github/workflows/publish_maven.yml
+++ b/.github/workflows/publish_maven.yml
@@ -1,0 +1,60 @@
+name: publish-maven
+on:
+  push:
+    tags: ['v*.*.*']
+permissions:
+  contents: read
+  packages: write
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set OWNER/REPO env
+        run: |
+          echo "OWNER=${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_ENV
+          echo "REPO=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          server-id: github
+          settings-path: ${{ github.workspace }}
+
+      - name: Export OpenAPI
+        run: python scripts/export_openapi.py
+      - name: Install OpenAPI Generator
+        uses: openapi-generators/openapi-generator-action@v1
+        with:
+          generator: java
+          openapi-file: ./docs/openapi.json
+          config-file: ./clients/java/openapi-config.yaml
+          command-args: -o clients/java
+
+      - name: Write settings.xml for GitHub Packages
+        run: |
+          cat > settings.xml <<'XML'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server>
+                <id>github</id>
+                <username>${env.GITHUB_ACTOR}</username>
+                <password>${env.GITHUB_TOKEN}</password>
+              </server>
+            </servers>
+          </settings>
+          XML
+
+      - name: Replace OWNER/REPO in pom.xml
+        run: |
+          sed -i "s#OWNER#${OWNER}#g" clients/java/pom.xml
+          sed -i "s#REPO#${REPO}#g" clients/java/pom.xml
+
+      - name: Build & Deploy
+        working-directory: clients/java
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn -s $GITHUB_WORKSPACE/settings.xml -B -DskipTests deploy

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -1,0 +1,36 @@
+name: publish-nuget
+on:
+  push:
+    tags: ['v*.*.*']
+permissions:
+  contents: read
+  packages: write
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Export OpenAPI
+        run: python scripts/export_openapi.py
+
+      - name: Generate C# client from OpenAPI
+        uses: openapi-generators/openapi-generator-action@v1
+        with:
+          generator: csharp-netcore
+          openapi-file: ./docs/openapi.json
+          command-args: -o clients/csharp -p packageName=SurgicalAI.Client
+
+      - name: Pack
+        working-directory: clients/csharp
+        run: dotnet pack -c Release -o out
+
+      - name: Publish to GitHub Packages (NuGet)
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: dotnet nuget push clients/csharp/out/*.nupkg --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --api-key $NUGET_AUTH_TOKEN

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -1,0 +1,27 @@
+name: release-docker
+on:
+  push:
+    tags: ['v*.*.*']
+permissions:
+  contents: read
+  packages: write
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        run: |
+          IMAGE=ghcr.io/${{ github.repository_owner }}/surgicalai:${GITHUB_REF_NAME}
+          docker build -t $IMAGE -f Dockerfile .
+          docker tag $IMAGE ghcr.io/${{ github.repository_owner }}/surgicalai:latest
+      - name: Push image
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/surgicalai:${GITHUB_REF_NAME}
+          docker push ghcr.io/${{ github.repository_owner }}/surgicalai:latest

--- a/README.md
+++ b/README.md
@@ -78,3 +78,42 @@ See [docs/IO_SCHEMA.md](docs/IO_SCHEMA.md) for data contracts.
 ## License
 
 Apache-2.0
+
+## GitHub Packages
+
+### Docker (GHCR)
+Pull:
+
+docker pull ghcr.io/openai/surgicalai:latest
+
+### Java (Maven)
+In `settings.xml`:
+```xml
+<server><id>github</id><username>YOUR_GH_USER</username><password>YOUR_PAT_with_read:packages</password></server>
+```
+In pom.xml:
+```
+<repositories><repository><id>github</id><url>https://maven.pkg.github.com/openai/SurgicalAI</url></repository></repositories>
+<dependency><groupId>io.github.openai</groupId><artifactId>surgicalai-client</artifactId><version>1.0.0</version></dependency>
+```
+### .NET (NuGet)
+
+Create NuGet.config:
+```
+<configuration>
+  <packageSources>
+    <add key="github" value="https://nuget.pkg.github.com/openai/index.json" />
+  </packageSources>
+  <packageSourceCredentials>
+    <github>
+      <add key="Username" value="YOUR_GH_USER" />
+      <add key="ClearTextPassword" value="YOUR_PAT_with_read:packages" />
+    </github>
+  </packageSourceCredentials>
+</configuration>
+```
+
+Install:
+```
+dotnet add package SurgicalAI.Client --version 1.0.0
+```

--- a/clients/csharp/SurgicalAI.Client.csproj
+++ b/clients/csharp/SurgicalAI.Client.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PackageId>SurgicalAI.Client</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>openai</Authors>
+    <RepositoryUrl>https://github.com/openai/SurgicalAI</RepositoryUrl>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+</Project>

--- a/clients/java/openapi-config.yaml
+++ b/clients/java/openapi-config.yaml
@@ -1,0 +1,7 @@
+library: okhttp-gson
+artifactId: surgicalai-client
+groupId: io.github.OWNER   # replace OWNER in pom.xml distribution URL too
+artifactVersion: 1.0.0
+dateLibrary: java8
+hideGenerationTimestamp: true
+useRuntimeException: true

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.github.OWNER</groupId> <!-- replace OWNER -->
+  <artifactId>surgicalai-client</artifactId>
+  <version>1.0.0</version>
+  <name>SurgicalAI Java Client</name>
+
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <url>https://maven.pkg.github.com/OWNER/REPO</url> <!-- replace OWNER/REPO -->
+    </repository>
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId><artifactId>okhttp</artifactId><version>4.12.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId><artifactId>gson</artifactId><version>2.11.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId><artifactId>maven-source-plugin</artifactId><version>3.3.0</version>
+        <executions><execution><id>attach-sources</id><goals><goal>jar-no-fork</goal></goals></execution></executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId><artifactId>maven-javadoc-plugin</artifactId><version>3.6.3</version>
+        <executions><execution><id>attach-javadocs</id><goals><goal>jar</goal></goals></execution></executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -1,0 +1,10 @@
+import json, os, pathlib
+from importlib import import_module
+# Import FastAPI app at src/surgicalai/api/main.py with variable "app"
+mod = import_module("src.surgicalai.api.main")
+app = getattr(mod, "app")
+openapi = app.openapi()
+out = pathlib.Path("docs/openapi.json")
+out.parent.mkdir(parents=True, exist_ok=True)
+out.write_text(json.dumps(openapi, indent=2), encoding="utf-8")
+print(f"Wrote {out}")


### PR DESCRIPTION
## Summary
- add script to export FastAPI OpenAPI schema
- publish Docker image, Java client, and .NET client to GitHub Packages
- document how to consume packages from GHCR, Maven, and NuGet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68971e0064cc8332abfe0ca72d08c466