### PR TITLE
Update CI workflow to Node 20 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,18 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
       - run: pip install -r requirements.txt
       - run: pip install -e .
       - run: pytest -q
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: demo-output
           path: outputs/demo


### PR DESCRIPTION
## Summary
- chore: update GitHub Actions to latest versions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'trimesh')*


------
https://chatgpt.com/codex/tasks/task_e_689725cfc8a48332b5d03c36b0437527