### PR TITLE
Use headless OpenCV and correct grad-cam package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip setuptools wheel
       - run: pip install -r requirements.txt
       - run: pip install -e .
       - run: pytest -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,12 @@ trimesh
 torch
 torchvision
 pillow
-opencv-python
+opencv-python-headless
 scikit-image
 pydantic
 typer
 rich
-pytorch-grad-cam
+grad-cam
 fastapi
 uvicorn
 matplotlib


### PR DESCRIPTION
## Summary
- fix dependency name to `grad-cam`
- switch to headless OpenCV for CI
- harden GitHub Actions by upgrading pip before installs

## Testing
- `python -m pip install --upgrade pip setuptools wheel`
- `python -m pip install -r requirements.txt` *(failed: Operation cancelled by user)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'trimesh')*

------
https://chatgpt.com/codex/tasks/task_e_689727bd23a88332afb7b6a698989cd1