### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+branch = True
+source =
+    surgicalai
+omit =
+    */__init__.py
+    */tests/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if TYPE_CHECKING:
+    if __name__ == '__main__':
+show_missing = True
+precision = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,36 @@ jobs:
         run: python -m pip install --upgrade pip setuptools wheel
       - run: python -m pip install -r requirements-dev.txt
       - run: python -m pip install -e .
-      - run: python -m pytest -q
+      - name: Run tests with coverage
+        run: |
+          python -m pytest -q \
+            --cov=surgicalai \
+            --cov-report=term-missing \
+            --cov-report=xml:coverage.xml \
+            --cov-report=html:htmlcov \
+            --cov-fail-under=80
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: |
+            coverage.xml
+            htmlcov
+      - name: Post coverage to job summary
+        run: |
+          python - <<'PY'
+import xml.etree.ElementTree as ET
+r = ET.parse("coverage.xml").getroot().attrib.get("line-rate", "0")
+pct = float(r) * 100
+print(f"Total coverage: {pct:.2f}%")
+open("/tmp/summary.md","w").write(f"## Coverage\n\n**Total:** {pct:.2f}%\n\nSee artifact `coverage-reports` for HTML details.")
+PY
+          cat /tmp/summary.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          fail_ci_if_error: true
       - uses: actions/upload-artifact@v4
         with:
           name: demo-output

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SurgicalAI
 
+[![codecov](https://codecov.io/gh/<owner>/<repo>/branch/main/graph/badge.svg)](https://codecov.io/gh/<owner>/<repo>)
+
 **Research Prototype – Not for Clinical Use**
 
 Minimal pipeline demonstrating analysis, planning and visualization for reconstructive surgery.


### PR DESCRIPTION
## Summary
- collect coverage with pytest-cov and enforce 80% threshold
- publish coverage artifacts and job summary
- upload results to Codecov and show badge in README

## Testing
- `python -m pytest -q --cov=surgicalai --cov-report=term-missing --cov-report=xml:coverage.xml --cov-report=html:htmlcov --cov-fail-under=80` *(fails: Required test coverage of 80% not reached. Total coverage: 57.56%)*

------
https://chatgpt.com/codex/tasks/task_e_68973f02fa3483329bccdb60efdd9144