### PR TITLE
Add packaging command and clean docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 Minimal pipeline for reconstructive surgery research.
 
-## Quickstart
+## One-Command Demo
 
 ```bash
 git clone <repo> && cd SurgicalAI
 make demo
 ```
 
-Outputs appear in `runs/demo/` and open in a browser. The demo uses only synthetic data and runs entirely on CPU.
+Outputs appear in `runs/demo/` and open in a browser. The demo uses only synthetic data and runs entirely on CPU. See [docs/IO_SCHEMA.md](docs/IO_SCHEMA.md) for the output contract.
 
 ## CLI
 
@@ -36,6 +36,15 @@ docker build -t ghcr.io/<YOURORG>/surgicalai:dev .
 ```
 
 GHCR TBD.
+
+## Packaging
+
+```bash
+surgicalai package
+dist/SurgicalAI --demo --out outputs/demo_exe
+```
+
+Troubleshooting PyInstaller: if packaging fails due to missing DLLs or data (e.g., `torch`, `torchvision`, or `open3d`), add `--hidden-import` or `--collect-all <pkg>` in `surgicalai.spec`.
 
 ## Privacy
 

--- a/clients/csharp/SurgicalAI.Client.csproj
+++ b/clients/csharp/SurgicalAI.Client.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageId>SurgicalAI.Client</PackageId>
     <Version>1.0.0</Version>
-    <Authors>openai</Authors>
-    <RepositoryUrl>https://github.com/openai/SurgicalAI</RepositoryUrl>
+    <Authors>YOURNAME</Authors> <!-- replace -->
+    <RepositoryUrl>https://github.com/YOURORG/SurgicalAI</RepositoryUrl> <!-- replace -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 </Project>

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ scikit-learn
 onnx
 onnxruntime
 openai
+pyinstaller

--- a/surgicalai/cli.py
+++ b/surgicalai/cli.py
@@ -63,5 +63,14 @@ def ui() -> None:
     ui_mod.launch()
 
 
+@app.command()
+def package() -> None:
+    """Build standalone executable via PyInstaller."""
+    import PyInstaller.__main__
+
+    spec = Path(__file__).resolve().parent.parent / "surgicalai.spec"
+    PyInstaller.__main__.run([str(spec)])
+
+
 if __name__ == "__main__":  # pragma: no cover
     app()


### PR DESCRIPTION
## Summary
- document a one-command demo and link to IO schema
- add PyInstaller packaging command with troubleshooting tips
- scrub OpenAI placeholders from C# client and include PyInstaller requirement

## Testing
- `surgicalai demo --input data/lesions_sample --out outputs/demo`
- `surgicalai package` *(fails: NameError: name '__file__' is not defined)*
- `ruff check .`
- `black --check .`
- `mypy surgicalai`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'surgicalai')*


------
https://chatgpt.com/codex/tasks/task_e_6897659b405883329614daf11e1bd6d2