### PR TITLE
Fix package imports and load environment for SurgicalAI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 openai>=1.40.0
 fastapi>=0.111.0
-uvicorn>=0.30.0
+uvicorn[standard]>=0.30.0
 pydantic>=2.7.0
 PyYAML>=6.0.1
 httpx>=0.27.0
 python-dotenv>=1.0.1
-starlette>=0.37.2


### PR DESCRIPTION
## Summary
- load `.env` before reading settings and switch to absolute package imports
- unify `/api/infer` into a single GET/POST handler
- streamline dependencies and add `uvicorn[standard]`

## Testing
- `python -m py_compile server/server.py server/settings.py server/rate_limit.py server/schemas.py`
- `python -m uvicorn server.server:app --host 127.0.0.1 --port 8000` (curl /healthz, /docs, /api/infer GET+POST, /api/stream, `/`)


------
https://chatgpt.com/codex/tasks/task_e_68979593699c8332b658263d278f9707