### PR TITLE
Guard temperature for unsupported models

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -7,7 +7,6 @@ with open(ROOT / "settings.yaml", "r") as f:
 
 class AppSettings(BaseModel):
     model: str = os.getenv("OPENAI_MODEL", CFG.get("model", "gpt-5-mini"))
-    temperature: float = CFG.get("temperature", 0.2)
     max_output_tokens: int = CFG.get("max_output_tokens", 800)
     caps: dict = CFG.get("caps", {})
     timeout_s: int = int(os.getenv("OPENAI_TIMEOUT_SECONDS", "45"))

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,5 +1,4 @@
 model: "gpt-5-mini"     # fast UI glue; pin heavier routes to "gpt-5"
-temperature: 0.2
 max_output_tokens: 800
 ui_streaming: true
 


### PR DESCRIPTION
## Summary
- prevent sending `temperature` to reasoning models by gating with `NO_TEMP_MODELS`
- add conditional `inference_config` for supported models
- remove global temperature setting from configuration

## Testing
- `python -m py_compile server/server.py server/settings.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68979ed98de48332aed52b8efe516770