### PR TITLE
Handle triage label strings in demo

### DIFF
--- a/surgicalai_demo/pipeline.py
+++ b/surgicalai_demo/pipeline.py
@@ -135,7 +135,7 @@ def run_demo(
     }
     metrics_mm = defect_metrics_px_to_mm(metrics_px, mm_per_px) if mm_per_px else None
 
-    # 5) Tier‑0 triage — returns STRING label; never access .label
+    # 5) Tier‑0 triage — returns STRING label; use directly without attribute access
     tri_label = triage_tier0(abcde, age=meta["age"], body_site=meta["body_site"])
     
     # 6) Very simple class probs for planner (demo safe)
@@ -188,7 +188,7 @@ def run_demo(
 
     summary: Dict[str, Any] = {
           "triage": {
-            "label": str(tri_label),   # ← IMPORTANT: string, no .label access
+            "label": str(tri_label),
         },
         "probs": probs,
         "plan": plan,


### PR DESCRIPTION
## Summary
- Document that triage_tier0 returns a string label and store it without attribute access
- Simplify triage summary entry to use the plain string label

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68999a9489048332aebcb184a24c97b4